### PR TITLE
panel: Add layout for initial setup mode

### DIFF
--- a/ui/panel.js
+++ b/ui/panel.js
@@ -65,6 +65,13 @@ const _panelModes = {
                     'powerButton'],
         },
     },
+    'initial-setup': {
+        panel: {
+            left: [],
+            center: [],
+            right: ["a11y", "keyboard", "systemMenu", 'powerButton'],
+        },
+    },
 };
 
 let _extraIndicators = [];


### PR DESCRIPTION
This layout is the same as on Endless 3.8 gnome-shell. Note that upstream uses 'aggregateMenu' while the panel extension uses 'systemMenu' which serves the same functionality but includes our downstream customizations.

See also https://github.com/endlessm/gnome-initial-setup/pull/316 (**not** a hard dep).

https://phabricator.endlessm.com/T30445