### PR TITLE
appIconBar: Close menus when showing icon tooltip

### DIFF
--- a/ui/appIconBar.js
+++ b/ui/appIconBar.js
@@ -491,6 +491,7 @@ const AppIconButton = GObject.registerClass({
         if (this._label.get_parent())
             return;
 
+        this._closeOtherMenus(BoxPointer.PopupAnimation.FULL);
         Main.uiGroup.add_actor(this._label);
         Main.uiGroup.set_child_above_sibling(this._label, null);
 


### PR DESCRIPTION
This fixes an issue found during last master playthrough where the icon menu would not hide properly when there are multiple windows in an application and we move the cursor on top of another icon which causes the tooltip to be displayed.

https://phabricator.endlessm.com/T30445