### PR TITLE
appFavorites: Do not show notification when adding/removing to/from favorites

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,7 @@ sources = [
   'utils.js',
 ]
 ui_sources = [
+  'ui/appFavorites.js',
   'ui/appIconBar.js',
   'ui/automaticUpdates.js',
   'ui/endlessButton.js',

--- a/ui/appFavorites.js
+++ b/ui/appFavorites.js
@@ -1,0 +1,34 @@
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+/* exported enable, disable */
+/*
+ * Copyright © 2020 Endless OS Foundation LLC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+const AppFavorites = imports.ui.appFavorites;
+
+const ExtensionUtils = imports.misc.extensionUtils;
+const PanelExtension = ExtensionUtils.getCurrentExtension();
+const Utils = PanelExtension.imports.utils;
+
+function enable() {
+    Utils.override(AppFavorites.AppFavorites, 'removeFavorite', function(appId) {
+        this._removeFavorite(appId);
+    });
+}
+
+function disable() {
+    Utils.restore(AppFavorites.AppFavorites);
+}

--- a/ui/panelManager.js
+++ b/ui/panelManager.js
@@ -22,6 +22,7 @@ const { GObject } = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const PanelExtension = ExtensionUtils.getCurrentExtension();
 
+const AppFavoritesWrapper = PanelExtension.imports.ui.appFavorites;
 const LayoutManagerWrapper = PanelExtension.imports.ui.layout;
 const PanelWrapper = PanelExtension.imports.ui.panel;
 const OverviewWrapper = PanelExtension.imports.ui.overview;
@@ -43,6 +44,7 @@ class PanelManager extends GObject.Object {
         OverviewWrapper.enable();
         PanelWrapper.enable();
         LayoutManagerWrapper.enable();
+        AppFavoritesWrapper.enable();
 
         this.enabled = true;
     }
@@ -55,6 +57,7 @@ class PanelManager extends GObject.Object {
         OverviewWrapper.disable();
         PanelWrapper.disable();
         LayoutManagerWrapper.disable();
+        AppFavoritesWrapper.disable();
 
         this.enabled = false;
     }


### PR DESCRIPTION
This brings the same behaviour as it was on Endless 3.8 gnome-shell when pinning/unpinning icons to/from the taskbar.

https://phabricator.endlessm.com/T30445