### PR TITLE
automaticUpdates: Hide Updates Queue menu item if the session mode doesn't allow changing settings

### DIFF
--- a/ui/automaticUpdates.js
+++ b/ui/automaticUpdates.js
@@ -82,7 +82,7 @@ class AutomaticUpdatesIndicator extends PanelMenu.SystemIndicator {
 
         this._item = new PopupMenu.PopupSubMenuMenuItem('', true);
         this._toggleItem = this._item.menu.addAction('', this._toggleAutomaticUpdates.bind(this));
-        this._item.menu.addAction(_('Updates Queue'),
+        this._updatesQueueItem = this._item.menu.addAction(_('Updates Queue'),
             () => {
                 const params = new GLib.Variant('(sava{sv})', [
                     'set-mode', [new GLib.Variant('s', 'updates')],
@@ -107,6 +107,9 @@ class AutomaticUpdatesIndicator extends PanelMenu.SystemIndicator {
                         }
                     });
             });
+        // Unlike settings action menu items, normal action menu items are not kept
+        // automatically in sync with SessionMode.allowSettings, let's do it manually
+        this._updatesQueueItem.visible = Main.sessionMode.allowSettings;
         this._item.menu.addSettingsAction(_('Set a Schedule'), UPDATES_PANEL_LAUNCHER);
         this.menu.addMenuItem(this._item);
 
@@ -410,6 +413,7 @@ class AutomaticUpdatesIndicator extends PanelMenu.SystemIndicator {
         const state = this._getState();
 
         this._item.visible = state !== AutomaticUpdatesState.DISCONNECTED;
+        this._updatesQueueItem.visible = Main.sessionMode.allowSettings;
         this.visible = state === AutomaticUpdatesState.DOWNLOADING;
     }
 


### PR DESCRIPTION
Noticed this issue during installation, where the `Automatic Updates -> Updates Queue` menu would be visible during initial setup and clicking on it would open the App Center.

Tbh, I'm not even sure if we should be showing the Automatic Updates menu at all during initial setup, but we do show it on 3.8 as well (and with the same issue here), so keeping it but fixing the issue.

https://phabricator.endlessm.com/T30445