### PR TITLE
appFavorites: Actually do not show notification when adding to favorites

### DIFF
--- a/ui/appFavorites.js
+++ b/ui/appFavorites.js
@@ -24,6 +24,10 @@ const PanelExtension = ExtensionUtils.getCurrentExtension();
 const Utils = PanelExtension.imports.utils;
 
 function enable() {
+    Utils.override(AppFavorites.AppFavorites, 'addFavoriteAtPos', function(appId, pos) {
+        this._addFavorite(appId, pos);
+    });
+
     Utils.override(AppFavorites.AppFavorites, 'removeFavorite', function(appId) {
         this._removeFavorite(appId);
     });


### PR DESCRIPTION
This brings the same behaviour as it was on Endless 3.8 gnome-shell when pinning icons to the taskbar.

https://phabricator.endlessm.com/T30445