### PR TITLE
appIconBar: Add indicator for running apps (v1)

### DIFF
--- a/stylesheet.scss
+++ b/stylesheet.scss
@@ -80,9 +80,15 @@ popup-separator-menu-item {
 
 .app-icon-button {
     background: none;
-    &:highlighted {
+
+    &:running {
+        // Trick due to St limitations. It needs a background to draw a box-shadow
+        background-color: rgba(0, 0, 0, 0.01);
+        box-shadow: inset 0 -1px 0 0 rgba(53, 132, 228, 0.9);
+    }
+    &:active {
         background-image: url("data/icons/mini-icon-active-indicator.png");
-        background-position: 2px 34px;
+        background-position: 2px 33px;
     }
 }
 


### PR DESCRIPTION
Right now there is no way to distinguish running apps from non-running apps apart from the active app which is already highlighted. This change adds an indicator for running apps as well, even if not active.

Alternative impl at https://github.com/endlessm/eos-panel-extension/pull/15.

https://phabricator.endlessm.com/T30445