### PR TITLE
appIconBar: Also export AppIconButton and ScrolledIconList

### DIFF
--- a/ui/appIconBar.js
+++ b/ui/appIconBar.js
@@ -1,5 +1,5 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
-/* exported AppIconBar */
+/* exported AppIconBar, AppIconButton, ScrolledIconList */
 /*
  * Copyright © 2020 Endless OS Foundation LLC
  *
@@ -255,7 +255,7 @@ const AppIconMenu = class extends PopupMenu.PopupMenu {
  *
  * This class handles the application icon
  */
-const AppIconButton = GObject.registerClass({
+var AppIconButton = GObject.registerClass({
     Signals: {
         'app-icon-pressed': {},
         'app-icon-pinned': {},
@@ -602,7 +602,7 @@ class AppIconBarNavButton extends St.Button {
     }
 });
 
-const ScrolledIconList = GObject.registerClass({
+var ScrolledIconList = GObject.registerClass({
     Signals: {
         'icons-scrolled': {},
         'app-icon-pressed': {},


### PR DESCRIPTION
These are used by the hack extension to override some methods.

This change should fix the following warnings:
```
  Some code accessed the property 'AppIconButton' on the module 'appIconBar'. That property was defined with 'let' or 'const' inside the module. This was previously supported, but is not correct according to the ES6 standard. Any symbols to be exported from a module must be defined with 'var'. The property access will work as previously for the time being, but please fix your code anyway.
  Some code accessed the property 'ScrolledIconList' on the module 'appIconBar'. That property was defined with 'let' or 'const' inside the module. This was previously supported, but is not correct according to the ES6 standard. Any symbols to be exported from a module must be defined with 'var'. The property access will work as previously for the time being, but please fix your code anyway.
```