### PR TITLE
systemMenu: Move remote-access indicator to the front

### DIFF
--- a/ui/systemMenu.js
+++ b/ui/systemMenu.js
@@ -73,6 +73,7 @@ class SystemMenu extends PanelMenu.Button {
         this._automaticUpdates = new AutomaticUpdates.Indicator();
         this._thunderbolt = new imports.ui.status.thunderbolt.Indicator();
 
+        this._indicators.add_child(this._remoteAccess);
         this._indicators.add_child(this._thunderbolt);
         this._indicators.add_child(this._nightLight);
         this._indicators.add_child(this._automaticUpdates);
@@ -82,7 +83,6 @@ class SystemMenu extends PanelMenu.Button {
             this._indicators.add_child(this._bluetooth);
         if (this._payg)
             this._indicators.add_child(this._payg);
-        this._indicators.add_child(this._remoteAccess);
         this._indicators.add_child(this._rfkill);
         this._indicators.add_child(this._volume);
         this._indicators.add_child(this._brightness);


### PR DESCRIPTION
This is aligned with latest changes from GNOME 3.38 - see
https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/1438.

https://phabricator.endlessm.com/T30172